### PR TITLE
Make 'has_blocks' work w/ parsed JSON

### DIFF
--- a/lib/colonel_kurtz/model/blockable.rb
+++ b/lib/colonel_kurtz/model/blockable.rb
@@ -9,7 +9,13 @@ module ColonelKurtz
 
           define_method "#{field}_blocks" do
             begin
-              JSON.parse(send(field)).map{ |data| ColonelKurtz::Block.new(data) }
+              content = send(field)
+
+              if content.is_a?(String)
+                content = JSON.parse(content)
+              end
+
+              content.map { |data| ColonelKurtz::Block.new(data) }
             rescue
               [] # TODO error handling
             end

--- a/spec/colonel_kurtz/model/blockable_spec.rb
+++ b/spec/colonel_kurtz/model/blockable_spec.rb
@@ -7,14 +7,10 @@ class BlockableExample
 
   has_blocks :content
 
-  attr_reader :data
+  attr_reader :content
 
-  def initialize(data)
-    @data = data
-  end
-
-  def content
-    JSON.generate(data)
+  def initialize(content)
+    @content = content
   end
 end
 
@@ -34,21 +30,37 @@ RSpec.describe BlockableExample do
     }
   end
 
-  subject { described_class.new(data) }
+  describe "with a JSON string" do
+    subject { described_class.new(JSON.generate(data)) }
 
-  describe ".has_blocks" do
-    it "creates 'field_blocks' accessor" do
-      should respond_to(:content_blocks)
+    describe ".has_blocks" do
+      it "creates 'field_blocks' accessor" do
+        should respond_to(:content_blocks)
+      end
+
+      it "returns an array" do
+        expect(subject.content_blocks).to be_a(Array)
+      end
+
+      it "returns an array of Blocks" do
+        block = subject.content_blocks.first
+
+        expect(block).to be_a(ColonelKurtz::Block)
+      end
     end
 
-    it "returns an array" do
-      expect(subject.content_blocks).to be_a(Array)
-    end
+    describe "with a parsed data structure" do
+      subject { described_class.new(data) }
 
-    it "returns an array of Blocks" do
-      block = subject.content_blocks.first
+      it "returns an array" do
+        expect(subject.content_blocks).to be_a(Array)
+      end
 
-      expect(block).to be_a(ColonelKurtz::Block)
+      it "returns an array of Blocks" do
+        block = subject.content_blocks.first
+
+        expect(block).to be_a(ColonelKurtz::Block)
+      end
     end
 
     context "with bad Colonel Kurtz data" do


### PR DESCRIPTION
We're using the JSON column type for our content, which Rails automatically parses, so calling `JSON.parse` on it throws errors.
