### PR TITLE
Update spec_helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,12 @@ rvm:
   - 2.1.0
   - 2.2.1
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 before_install: gem install bundler -v 1.10.2
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.configure do |config|
-  config.logger.level = Logger::WARN
+require 'simplecov'
+
+SimpleCov.start "rails" do
+  minimum_coverage 95
 end
-CodeClimate::TestReporter.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 
 SimpleCov.start "rails" do
-  minimum_coverage 95
+  minimum_coverage 85
 end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)


### PR DESCRIPTION
# Problem
When running tests locally, I got a warning:
```  
This usage of the Code Climate Test Reporter is now deprecated. Since version 1.0, 
we now require you to run `SimpleCov` in your test/spec helper, and then run the 
provided `codeclimate-test-reporter` binary separately to report your results to 
Code Climate.

More information here: https://github.com/codeclimate/ruby-test-reporter/b
lob/master/README.md
```

# Solution
Update the spec_helper to use SimpleCov instead. The current gemspec includes it via the code climate dev dependency. 

Update `.travis.yml` to use the recommended cc runner. [Followed the guide](https://docs.codeclimate.com/docs/travis-ci-test-coverage)