### PR TITLE
Add ActiveRecord::Serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ end
 
 Big wins! :tada:
 
-#### What if I'm already storing the blocks as strings?
+#### What if I'm already storing the blocks as text?
 
-If you're currently storing CK content as strings, you can update the content to
+If you're currently storing CK content as text, you can update the content to
 be JSONB with this example migration. `Page` is an example ActiveRecord with a
 column `content` that represents the ColonelKurtz data.
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ class ChangePageContentToJson < ActiveRecord::Migration[5.2]
     change_column :pages, :content, 'text USING CAST(content AS text)'
   end
 end
+
+## When creating new tables
+
+class CreatePages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pages do |t|
+      # ...
+
+      t.jsonb :content, null: false, default: []
+
+      # ...
+    end
+  end
+end
 ```
 
 [Read more about JSON indexes in

--- a/colonel_kurtz_ruby.gemspec
+++ b/colonel_kurtz_ruby.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec",         "~> 3.2"
   spec.add_development_dependency "pry",           "~> 0.10"
   spec.add_development_dependency "activesupport", "~> 4.2"
+  spec.add_development_dependency "activerecord",  ">= 1.0"
 
   spec.add_development_dependency "codeclimate-test-reporter"
 end

--- a/lib/colonel_kurtz.rb
+++ b/lib/colonel_kurtz.rb
@@ -1,6 +1,7 @@
 require "colonel_kurtz/version"
 
 require "colonel_kurtz/block"
+require "colonel_kurtz/active_record/serializer"
 require "colonel_kurtz/block/data"
 require "colonel_kurtz/block/type"
 

--- a/lib/colonel_kurtz/active_record/serializer.rb
+++ b/lib/colonel_kurtz/active_record/serializer.rb
@@ -1,0 +1,39 @@
+module ColonelKurtz
+  module ActiveRecord
+    class Serializer
+      def self.load(value)
+        case value
+        when String
+          value
+        when NilClass
+          ''
+        when Hash, Array
+          value.to_json
+        else
+          raise_mismatch(value)
+        end
+      end
+
+      def self.dump(value)
+        case value
+        when String
+          JSON.parse(value)
+        when NilClass
+          []
+        when Hash, Array
+          value
+        else
+          raise_mismatch(value)
+        end
+      end
+
+      def self.raise_mismatch(obj)
+        raise(
+          ::ActiveRecord::SerializationTypeMismatch,
+          %(Attribute was supposed to be a ColonelKurtz block,
+          but was a #{obj.class}. -- #{obj.inspect})
+        )
+      end
+    end
+  end
+end

--- a/spec/colonel_kurtz/active_record/serializer_spec.rb
+++ b/spec/colonel_kurtz/active_record/serializer_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+RSpec.describe ColonelKurtz::ActiveRecord::Serializer do
+  describe ".load" do
+    context "when value is a String" do
+      it "returns as a string" do
+        result = described_class.load('test')
+        expect(result).to eq 'test'
+      end
+    end
+
+    context "when value is nil" do
+      it "returns as an empty string" do
+        result = described_class.load(nil)
+        expect(result).to eq ''
+      end
+    end
+
+    context "when value is a Hash or Array" do
+      it "returns as a serialized json string" do
+        hash_result = described_class.load(test: "value")
+        expect(hash_result).to eq '{"test":"value"}'
+
+        array_result = described_class.load(["value"])
+        expect(array_result).to eq '["value"]'
+      end
+    end
+
+    context "when value is unexpected" do
+      require 'active_record/errors'
+
+      it "raises a SerializationTypeMismatch" do
+        expect { described_class.load(123) }.to raise_error(ActiveRecord::SerializationTypeMismatch)
+      end
+    end
+  end
+
+  describe ".dump" do
+    context "when value is a String" do
+      it "returns as a Hash" do
+        result = described_class.dump('{"test":"value"}')
+        expect(result).to eq Hash["test" => "value"]
+      end
+    end
+
+    context "when value is nil" do
+      it "returns as an empty Array" do
+        result = described_class.dump(nil)
+        expect(result).to eq []
+      end
+    end
+
+    context "when value is a Hash or Array" do
+      it "passes through" do
+        hash = Hash["test" => "value"]
+        hash_result = described_class.dump(hash)
+        expect(hash_result).to eq hash
+
+        array = ["value"]
+        array_result = described_class.dump(array)
+        expect(array_result).to eq array
+      end
+    end
+
+    context "when value is unexpected" do
+      require 'active_record/errors'
+
+      it "raises a SerializationTypeMismatch" do
+        expect { described_class.load(123) }.to raise_error(ActiveRecord::SerializationTypeMismatch)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding a feature to serialize the CK block data as JSON so queries can introspect on the data.

CI should pass again once #3 is merged.